### PR TITLE
Resolve compiler tool basenames to absolute paths

### DIFF
--- a/recipe/gen-bazel-toolchain
+++ b/recipe/gen-bazel-toolchain
@@ -5,6 +5,24 @@ set -euxo pipefail
 CC=$(command -v "${CC}")
 CC_FOR_BUILD=$(command -v "${CC_FOR_BUILD}")
 
+# Compiler activation may export tool basenames only. These values are embedded
+# as toolchain tool paths under //bazel_toolchain; relative names become missing
+# sandbox files (e.g. bazel_toolchain/x86_64-conda-linux-gnu-gcc).
+# Resolve to absolute paths, matching the handling of CC above.
+# See: https://github.com/conda-forge/grpc_java_plugin-feedstock/pull/114
+if [[ -n "${GCC:-}" ]]; then
+  GCC=$(command -v "${GCC}")
+fi
+if [[ -n "${LD:-}" ]]; then
+  LD=$(command -v "${LD}")
+fi
+if [[ -n "${NM:-}" ]]; then
+  NM=$(command -v "${NM}")
+fi
+if [[ -n "${STRIP:-}" ]]; then
+  STRIP=$(command -v "${STRIP}")
+fi
+
 if [ ! -n "${target_platform-}" ] || [ "${target_platform}" == "noarch" ]; then
   if [ -n "${host_platform-}" ]; then
     # If host_platform is set, we assume that build_platform is set too.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: bazel-toolchain
-  version: "0.5.11"
+  version: "0.5.12"
 
 package:
   name: ${{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Port https://github.com/conda-forge/grpc_java_plugin-feedstock/pull/114.

gcc_linux-64 14.4+ activation may export basename-only GCC/LD/NM/STRIP. Those values are embedded as toolchain tool paths under //bazel_toolchain, so Bazel looks for bazel_toolchain/<tool> in the sandbox and fails.

Resolve them with command -v, matching the existing CC handling. Fixes the Linux failure seen in conda-forge/grpc_java_plugin-feedstock#114.